### PR TITLE
Create 404-error-page

### DIFF
--- a/packages/nextjs/app/not-found.styles.tsx
+++ b/packages/nextjs/app/not-found.styles.tsx
@@ -1,0 +1,15 @@
+const styles = {
+  container: 'flex flex-col items-center justify-center min-h-screen bg-black text-green-400 text-center font-mono px-4',
+  title: 'text-4xl md:text-6xl font-bold mb-6 tracking-wider',
+  subtitle: 'text-base md:text-lg mb-8 leading-relaxed max-w-lg md:max-w-2xl',
+  section: 'mb-8 text-center px-4 md:px-0', //Ajustar márgenes en pantallas más pequeñas
+  sectionTitle: 'text-xl md:text-2xl font-bold mb-4 underline',
+  list: 'list-none space-y-2 text-sm md:text-base', //Ajustar tamaño de texto según la pantalla
+  footerText: 'text-sm md:text-lg mb-6',
+  ctaContainer: 'flex flex-col md:flex-row gap-4', //Botones en columna en pantallas pequeñas
+  cta: 'w-full md:w-auto px-4 py-2 bg-green-600 text-black font-bold rounded hover:bg-green-500 cursor-pointer transition-colors duration-300',
+};
+
+export default styles;
+
+  

--- a/packages/nextjs/app/not-found.styles.tsx
+++ b/packages/nextjs/app/not-found.styles.tsx
@@ -1,15 +1,19 @@
 const styles = {
-  container: 'flex flex-col items-center justify-center min-h-screen bg-black text-green-400 text-center font-mono px-4',
-  title: 'text-4xl md:text-6xl font-bold mb-6 tracking-wider',
+  container: 'flex flex-col items-center justify-center min-h-screen bg-black text-center font-mono px-4',
+  title: 'flex items-center justify-center gap-2 mb-6', //Contenedor del título 404 y Not Found
+  title404: 'text-9xl font-bold tracking-wider', //Estilo para 404
+  titleText: 'text-4xl font-bold tracking-wider mt-12', //Estilo para Not Found
   subtitle: 'text-base md:text-lg mb-8 leading-relaxed max-w-lg md:max-w-2xl',
-  section: 'mb-8 text-center px-4 md:px-0', //Ajustar márgenes en pantallas más pequeñas
-  sectionTitle: 'text-xl md:text-2xl font-bold mb-4 underline',
-  list: 'list-none space-y-2 text-sm md:text-base', //Ajustar tamaño de texto según la pantalla
+  section: 'mb-8 text-center px-4 md:px-0',
+  sectionTitle: 'text-xl md:text-2xl font-bold mb-4', //Sin subrayado
+  list: 'list-none space-y-2 text-sm md:text-base',
   footerText: 'text-sm md:text-lg mb-6',
-  ctaContainer: 'flex flex-col md:flex-row gap-4', //Botones en columna en pantallas pequeñas
-  cta: 'w-full md:w-auto px-4 py-2 bg-green-600 text-black font-bold rounded hover:bg-green-500 cursor-pointer transition-colors duration-300',
+  ctaContainer: 'flex items-center justify-center bg-green-600 rounded px-4 py-4', //Fondo verde con hover negro
+  cta: 'text-green-400 font-bold mx-4 cursor-pointer hover:text-black transition-colors duration-300', //Texto verde con hover consistente
+  separator: 'text-green-400 mx-2',
 };
 
 export default styles;
+
 
   

--- a/packages/nextjs/app/not-found.styles.tsx
+++ b/packages/nextjs/app/not-found.styles.tsx
@@ -9,7 +9,7 @@ const styles = {
   list: 'list-none space-y-2 text-sm md:text-base',
   footerText: 'text-sm md:text-lg mb-6',
   ctaContainer: 'flex items-center justify-center bg-green-600 rounded px-4 py-4', //Fondo verde con hover negro
-  cta: 'text-green-400 font-bold mx-4 cursor-pointer hover:text-black transition-colors duration-300', //Texto verde con hover consistente
+  cta: 'font-bold mx-4 cursor-pointer hover:text-black transition-colors duration-300', //Texto verde con hover consistente
   separator: 'text-green-400 mx-2',
 };
 

--- a/packages/nextjs/app/not-found.tsx
+++ b/packages/nextjs/app/not-found.tsx
@@ -4,9 +4,12 @@ import styles from './not-found.styles';
 export default function NotFound() {
   return (
     <div className={styles.container}>
-      <h1 className={styles.title}>404: Not Found</h1>
+      <div className={styles.title}>
+        <span className={styles.title404}>404</span>
+        <span className={styles.titleText}>:Not Found</span>
+      </div>
       <p className={styles.subtitle}>
-        Congratulations! You have successfully navigated to nowhere. This page is either missing, classified, or hiding from you specifically. :(
+        Congratulations! You've successfully navigated to nowhere. This page is either missing, classified, or hiding from you specifically. :(
       </p>
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>What Happens Next?</h2>
@@ -23,9 +26,11 @@ export default function NotFound() {
         <Link href="/" className={styles.cta}>
           Retreat Gracefully
         </Link>
+        <span className={styles.separator}>|</span>
         <Link href="/" className={styles.cta}>
           Try Again, But Smarter
         </Link>
+        <span className={styles.separator}>|</span>
         <Link href="/" className={styles.cta}>
           Report This to Someone Who Cares
         </Link>

--- a/packages/nextjs/app/not-found.tsx
+++ b/packages/nextjs/app/not-found.tsx
@@ -9,7 +9,7 @@ export default function NotFound() {
         <span className={styles.titleText}>: Not Found</span>
       </div>
       <p className={styles.subtitle}>
-        Congratulations! You've successfully navigated to nowhere. This page is either missing, classified, or hiding from you specifically. :(
+        Congratulations! You have successfully navigated to nowhere. This page is either missing, classified, or hiding from you specifically. :(
       </p>
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>What Happens Next?</h2>

--- a/packages/nextjs/app/not-found.tsx
+++ b/packages/nextjs/app/not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
     <div className={styles.container}>
       <div className={styles.title}>
         <span className={styles.title404}>404</span>
-        <span className={styles.titleText}>:Not Found</span>
+        <span className={styles.titleText}>: Not Found</span>
       </div>
       <p className={styles.subtitle}>
         Congratulations! You've successfully navigated to nowhere. This page is either missing, classified, or hiding from you specifically. :(

--- a/packages/nextjs/app/not-found.tsx
+++ b/packages/nextjs/app/not-found.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import styles from './not-found.styles';
+
+export default function NotFound() {
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>404: Not Found</h1>
+      <p className={styles.subtitle}>
+        Congratulations! You've successfully navigated to nowhere. This page is either missing, classified, or hiding from you specifically. :(
+      </p>
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>What Happens Next?</h2>
+        <ul className={styles.list}>
+          <li>A highly detailed (and completely unnecessary) error report has been filed.</li>
+          <li>IT has been notified. They are... unimpressed.</li>
+          <li>Security is now watching you with mild suspicion.</li>
+        </ul>
+      </div>
+      <p className={styles.footerText}>
+        For your own digital dignity, consider a different approach:
+      </p>
+      <div className={styles.ctaContainer}>
+        <Link href="/" className={styles.cta}>
+          Retreat Gracefully
+        </Link>
+        <Link href="/" className={styles.cta}>
+          Try Again, But Smarter
+        </Link>
+        <Link href="/" className={styles.cta}>
+          Report This to Someone Who Cares
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/packages/nextjs/app/not-found.tsx
+++ b/packages/nextjs/app/not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
     <div className={styles.container}>
       <h1 className={styles.title}>404: Not Found</h1>
       <p className={styles.subtitle}>
-        Congratulations! You've successfully navigated to nowhere. This page is either missing, classified, or hiding from you specifically. :(
+        Congratulations! You have successfully navigated to nowhere. This page is either missing, classified, or hiding from you specifically. :(
       </p>
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>What Happens Next?</h2>

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "next:lint:fix": "yarn workspace @ss-2/nextjs lint --fix"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.3",


### PR DESCRIPTION
This PR introduces a custom 404 error page with the following features:
- Responsive design for different screen sizes.
- Centered layout with retro-styled text and buttons.
- Consistent with the project's design guidelines.

No conflicts were found, and all changes were tested locally.

Go to a non-existent URL, such as http://localhost:3000/random-page, and check the result.
